### PR TITLE
Allow the user to provide a custom reference time

### DIFF
--- a/timingframework-core/src/main/java/org/jdesktop/core/animation/timing/Animator.java
+++ b/timingframework-core/src/main/java/org/jdesktop/core/animation/timing/Animator.java
@@ -1307,7 +1307,7 @@ public final class Animator implements TickListener {
             final boolean canPause = isRunning() && !f_stopping && f_pauseBeginTimeNanos == 0;
             if (canPause) {
                 f_timingSource.removeTickListener(this);
-                f_pauseBeginTimeNanos = System.nanoTime();
+                f_pauseBeginTimeNanos = f_timingSource.getNanoTime();
             }
         }
     }
@@ -1333,7 +1333,7 @@ public final class Animator implements TickListener {
         synchronized (this) {
             final boolean paused = isPaused();
             if (paused) {
-                long pauseDeltaNanos = System.nanoTime() - f_pauseBeginTimeNanos;
+                long pauseDeltaNanos = f_timingSource.getNanoTime() - f_pauseBeginTimeNanos;
                 f_startTimeNanos += pauseDeltaNanos;
                 f_cycleStartTimeNanos += pauseDeltaNanos;
                 f_pauseBeginTimeNanos = 0;
@@ -1411,7 +1411,7 @@ public final class Animator implements TickListener {
      *         time.
      */
     public long getCycleElapsedTime() {
-        return getCycleElapsedTime(System.nanoTime());
+        return getCycleElapsedTime(f_timingSource.getNanoTime());
     }
 
     /**
@@ -1440,7 +1440,7 @@ public final class Animator implements TickListener {
      * @return the total time elapsed in nanoseconds between the time this animation started and the current time.
      */
     public long getTotalElapsedTime() {
-        return getTotalElapsedTime(System.nanoTime());
+        return getTotalElapsedTime(f_timingSource.getNanoTime());
     }
 
     /**
@@ -1493,7 +1493,7 @@ public final class Animator implements TickListener {
                 throw new IllegalStateException(I18N.err(12, methodName));
             }
 
-            final long nanoTime = System.nanoTime();
+            final long nanoTime = f_timingSource.getNanoTime();
             f_startTimeNanos = nanoTime;
             f_cycleStartTimeNanos = nanoTime + f_startDelayNanos;
             f_currentDirection = direction;

--- a/timingframework-core/src/main/java/org/jdesktop/core/animation/timing/TimingSource.java
+++ b/timingframework-core/src/main/java/org/jdesktop/core/animation/timing/TimingSource.java
@@ -198,7 +198,7 @@ public abstract class TimingSource {
             }
             task.run();
         }
-        final long nanoTime = System.nanoTime();
+        final long nanoTime = getNanoTime();
         if (!f_tickListeners.isEmpty()) {
             for (TickListener listener : f_tickListeners) {
                 listener.timingSourceTick(TimingSource.this, nanoTime);
@@ -209,5 +209,17 @@ public abstract class TimingSource {
                 listener.timingSourcePostTick(TimingSource.this, nanoTime);
             }
         }
+    }
+    
+    /**
+     * Returns the reference time of this TimingSource in nanoseconds.
+     * By default, this method delegates to {@link System#nanoTime()}.
+     * Subclasses may override this method to provide their own reference time,
+     * such as a frame counter or an alternative high-precision timing source.
+     *
+     * @return the reference time in nanoseconds
+     */
+    public long getNanoTime() {
+        return System.nanoTime();
     }
 }


### PR DESCRIPTION
This PR allows the user to provide a custom reference time such as a frame counter or an alternative high-precision timing source.

Key Benefits:

- **Extensibility**: Developers can now easily adapt the framework to use custom timing mechanisms specific to their domain or application needs.
- **Flexibility**: The TimingFramework becomes more adaptable for advanced or niche scenarios, such as high-precision timing in game development or scientific simulations.
- **Compatibility**: Maintains seamless operation for existing users while providing a pathway for future enhancements.